### PR TITLE
Fix Compile errors on types

### DIFF
--- a/ck-core/src/main/scala/Service.scala
+++ b/ck-core/src/main/scala/Service.scala
@@ -4,20 +4,20 @@ import java.util.UUID
 
 package object service {
 
-  trait Command[+C <: ServiceClass[C]]
+  trait Command[C <: ServiceClass[C]]
 
-  trait Event[+C <: ServiceClass[C]]
+  trait Event[C <: ServiceClass[C]]
 
   type ServiceId[C <: ServiceClass[C]] = UUID
   type ClassId[C <: ServiceClass[C]] = UUID
-  type ServiceRef[+C <: ServiceClass[C]] = () => Service[C]
-  type Listener[-E <: Event[ServiceClass[_]]] = (E => ())
+  type ServiceRef[C <: ServiceClass[C]] = () => Service[C]
+  type Listener[C <: ServiceClass[C], E <: Event[C]] = Function1[Unit, E]
 
   implicit def callByName2StaticServiceRef[C <: ServiceClass[C]](f: => Service[C]): ServiceRef[C] = () => f
 }
 
 package service {
-  trait Service[+C <: ServiceClass[C]] {
+  trait Service[C <: ServiceClass[C]] {
 
     val id: ServiceId[C]
     val classId: ClassId[C]
@@ -26,11 +26,11 @@ package service {
 
     def send(c: Command[C])
 
-    def subscribe(l: Listener[Event[C]])
+    def subscribe(l: Listener[C, Event[C]])
 
   }
 
-  trait ServiceClass[+C <: ServiceClass[C]] {
+  trait ServiceClass[C <: ServiceClass[C]] {
 
     val classId: ClassId[C]
     val commands: Set[Command[C]]
@@ -40,7 +40,7 @@ package service {
   }
 
   trait ServiceDriver {
-    def consume: (Command[_]) => ()
+    def consume: Function1[Unit, Command[_]]
   }
 
   trait ServiceReference[C <: ServiceClass[C]] {


### PR DESCRIPTION
- Types are best either bound or (co|contra)variant, both makes things a little confusing. Also, upper bounds entail some covariance and lower bounds the opposite.
- Careful with function syntax for types: `()` is the _value_ of Unit, not shorthand for type `Unit`.